### PR TITLE
[03.08] Implement detect_two_pair function

### DIFF
--- a/include/poker.h
+++ b/include/poker.h
@@ -228,6 +228,20 @@ int detect_three_of_a_kind(const Card* cards, size_t len,
                             size_t* out_num_tiebreakers);
 
 /**
+ * @brief Detect two pair
+ * @param cards Array of exactly 5 cards
+ * @param len Must be 5
+ * @param counts Optional pre-computed rank counts (can be NULL)
+ * @param out_tiebreakers Output array for tiebreaker ranks
+ * @param out_num_tiebreakers Pointer to receive count of tiebreakers
+ * @return 1 if two pair, 0 otherwise
+ */
+int detect_two_pair(const Card* cards, size_t len,
+                    const int* counts,
+                    Rank* out_tiebreakers,
+                    size_t* out_num_tiebreakers);
+
+/**
  * @brief Detect straight flush
  * @param cards Array of exactly 5 cards
  * @param len Must be 5

--- a/src/evaluator.c
+++ b/src/evaluator.c
@@ -448,6 +448,93 @@ int detect_three_of_a_kind(const Card* cards, size_t len,
     return 1;
 }
 
+/**
+ * @brief Detect two pair
+ *
+ * Detects if the hand contains exactly two pairs (2 ranks with 2 cards each).
+ * Returns tiebreakers in the format: [high_pair, low_pair, kicker]
+ * where pairs are sorted in descending order.
+ *
+ * The function validates all input parameters and handles the optional counts
+ * parameter by computing counts internally if NULL is provided. It excludes
+ * full houses (trips with a pair) and quads.
+ *
+ * @param cards Array of exactly 5 cards
+ * @param len Must be 5
+ * @param counts Optional pre-computed rank counts (can be NULL)
+ * @param out_tiebreakers Output array for tiebreaker ranks
+ * @param out_num_tiebreakers Pointer to receive count of tiebreakers
+ * @return 1 if two pair, 0 otherwise
+ */
+int detect_two_pair(const Card* cards, size_t len,
+                    const int* counts,
+                    Rank* out_tiebreakers,
+                    size_t* out_num_tiebreakers) {
+    /* Validate input parameters */
+    if (cards == NULL || len != 5 || out_tiebreakers == NULL || out_num_tiebreakers == NULL) {
+        return 0;
+    }
+
+    /* Use provided counts or compute locally */
+    int local_counts[15];
+    const int* rank_count_array;
+
+    if (counts == NULL) {
+        rank_counts(cards, len, local_counts);
+        rank_count_array = local_counts;
+    } else {
+        rank_count_array = counts;
+    }
+
+    /* Check for trips or quads (count >= 3) - excludes full houses and quads */
+    for (int rank = RANK_TWO; rank <= RANK_ACE; rank++) {
+        if (rank_count_array[rank] >= 3) {
+            return 0;
+        }
+    }
+
+    /* Find exactly 2 ranks with count == 2 (pairs) */
+    Rank pairs[2];
+    int pair_count = 0;
+
+    for (int rank = RANK_TWO; rank <= RANK_ACE; rank++) {
+        if (rank_count_array[rank] == 2) {
+            if (pair_count < 2) {
+                pairs[pair_count++] = (Rank)rank;
+            }
+        }
+    }
+
+    /* Must have exactly 2 pairs */
+    if (pair_count != 2) {
+        return 0;
+    }
+
+    /* Sort pairs in descending order (high pair first) */
+    if (pairs[0] < pairs[1]) {
+        Rank temp = pairs[0];
+        pairs[0] = pairs[1];
+        pairs[1] = temp;
+    }
+
+    /* Find the kicker (count == 1) */
+    Rank kicker = 0;
+    for (int rank = RANK_TWO; rank <= RANK_ACE; rank++) {
+        if (rank_count_array[rank] == 1) {
+            kicker = (Rank)rank;
+            break;
+        }
+    }
+
+    /* Write tiebreakers: [high_pair, low_pair, kicker] */
+    out_tiebreakers[0] = pairs[0];  /* High pair */
+    out_tiebreakers[1] = pairs[1];  /* Low pair */
+    out_tiebreakers[2] = kicker;
+    *out_num_tiebreakers = 3;
+
+    return 1;
+}
+
 int evaluate_hand(void) {
     /* Placeholder for hand evaluation */
     return 0;

--- a/tests/test_detect_two_pair.c
+++ b/tests/test_detect_two_pair.c
@@ -1,0 +1,292 @@
+#include <assert.h>
+#include <stdio.h>
+#include "../include/poker.h"
+
+/*
+ * Test Suite for detect_two_pair function
+ * Tests verify two pair detection (2 ranks with 2 cards each)
+ */
+
+/* Test two pair: Aces and Kings with Queen kicker */
+void test_two_pair_aces_kings_queen(void) {
+    printf("Testing two pair: Aces and Kings with Queen kicker...\n");
+    Card cards[5] = {
+        {RANK_ACE, SUIT_HEARTS},
+        {RANK_ACE, SUIT_DIAMONDS},
+        {RANK_KING, SUIT_CLUBS},
+        {RANK_KING, SUIT_SPADES},
+        {RANK_QUEEN, SUIT_HEARTS}
+    };
+    Rank tiebreakers[3];
+    size_t num_tiebreakers = 0;
+
+    int result = detect_two_pair(cards, 5, NULL, tiebreakers, &num_tiebreakers);
+
+    assert(result == 1);
+    assert(num_tiebreakers == 3);
+    assert(tiebreakers[0] == RANK_ACE);    /* High pair */
+    assert(tiebreakers[1] == RANK_KING);   /* Low pair */
+    assert(tiebreakers[2] == RANK_QUEEN);  /* Kicker */
+    printf("  Pass: Two pair Aces-Kings with Queen kicker detected correctly\n");
+}
+
+/* Test two pair: Tens and Twos with Ace kicker */
+void test_two_pair_tens_twos_ace(void) {
+    printf("Testing two pair: Tens and Twos with Ace kicker...\n");
+    Card cards[5] = {
+        {RANK_TEN, SUIT_HEARTS},
+        {RANK_TEN, SUIT_DIAMONDS},
+        {RANK_TWO, SUIT_CLUBS},
+        {RANK_TWO, SUIT_SPADES},
+        {RANK_ACE, SUIT_HEARTS}
+    };
+    Rank tiebreakers[3];
+    size_t num_tiebreakers = 0;
+
+    int result = detect_two_pair(cards, 5, NULL, tiebreakers, &num_tiebreakers);
+
+    assert(result == 1);
+    assert(num_tiebreakers == 3);
+    assert(tiebreakers[0] == RANK_TEN);  /* High pair */
+    assert(tiebreakers[1] == RANK_TWO);  /* Low pair */
+    assert(tiebreakers[2] == RANK_ACE);  /* Kicker */
+    printf("  Pass: Two pair Tens-Twos with Ace kicker detected correctly\n");
+}
+
+/* Test two pair with unordered cards (test sorting) */
+void test_two_pair_unordered(void) {
+    printf("Testing two pair with unordered cards...\n");
+    Card cards[5] = {
+        {RANK_FIVE, SUIT_HEARTS},
+        {RANK_JACK, SUIT_DIAMONDS},
+        {RANK_FIVE, SUIT_CLUBS},
+        {RANK_THREE, SUIT_SPADES},
+        {RANK_JACK, SUIT_HEARTS}
+    };
+    Rank tiebreakers[3];
+    size_t num_tiebreakers = 0;
+
+    int result = detect_two_pair(cards, 5, NULL, tiebreakers, &num_tiebreakers);
+
+    assert(result == 1);
+    assert(num_tiebreakers == 3);
+    assert(tiebreakers[0] == RANK_JACK);  /* High pair (sorted) */
+    assert(tiebreakers[1] == RANK_FIVE);  /* Low pair (sorted) */
+    assert(tiebreakers[2] == RANK_THREE); /* Kicker */
+    printf("  Pass: Two pair with unordered cards sorted correctly\n");
+}
+
+/* Test two pair with pre-computed counts */
+void test_two_pair_with_counts(void) {
+    printf("Testing two pair with pre-computed counts...\n");
+    Card cards[5] = {
+        {RANK_NINE, SUIT_HEARTS},
+        {RANK_NINE, SUIT_DIAMONDS},
+        {RANK_FOUR, SUIT_CLUBS},
+        {RANK_FOUR, SUIT_SPADES},
+        {RANK_SEVEN, SUIT_HEARTS}
+    };
+
+    /* Pre-compute rank counts */
+    int counts[15];
+    rank_counts(cards, 5, counts);
+
+    Rank tiebreakers[3];
+    size_t num_tiebreakers = 0;
+
+    int result = detect_two_pair(cards, 5, counts, tiebreakers, &num_tiebreakers);
+
+    assert(result == 1);
+    assert(num_tiebreakers == 3);
+    assert(tiebreakers[0] == RANK_NINE);
+    assert(tiebreakers[1] == RANK_FOUR);
+    assert(tiebreakers[2] == RANK_SEVEN);
+    printf("  Pass: Two pair with pre-computed counts detected correctly\n");
+}
+
+/* Test full house (should NOT be two pair) */
+void test_full_house_not_two_pair(void) {
+    printf("Testing full house (not two pair)...\n");
+    Card cards[5] = {
+        {RANK_JACK, SUIT_HEARTS},
+        {RANK_JACK, SUIT_DIAMONDS},
+        {RANK_JACK, SUIT_CLUBS},
+        {RANK_TWO, SUIT_HEARTS},
+        {RANK_TWO, SUIT_DIAMONDS}
+    };
+    Rank tiebreakers[3];
+    size_t num_tiebreakers = 0;
+
+    int result = detect_two_pair(cards, 5, NULL, tiebreakers, &num_tiebreakers);
+
+    assert(result == 0);
+    printf("  Pass: Full house correctly identified as non-two-pair\n");
+}
+
+/* Test three of a kind (should NOT be two pair) */
+void test_three_of_a_kind_not_two_pair(void) {
+    printf("Testing three of a kind (not two pair)...\n");
+    Card cards[5] = {
+        {RANK_EIGHT, SUIT_HEARTS},
+        {RANK_EIGHT, SUIT_DIAMONDS},
+        {RANK_EIGHT, SUIT_CLUBS},
+        {RANK_KING, SUIT_HEARTS},
+        {RANK_QUEEN, SUIT_DIAMONDS}
+    };
+    Rank tiebreakers[3];
+    size_t num_tiebreakers = 0;
+
+    int result = detect_two_pair(cards, 5, NULL, tiebreakers, &num_tiebreakers);
+
+    assert(result == 0);
+    printf("  Pass: Three of a kind correctly identified as non-two-pair\n");
+}
+
+/* Test four of a kind (should NOT be two pair) */
+void test_four_of_a_kind_not_two_pair(void) {
+    printf("Testing four of a kind (not two pair)...\n");
+    Card cards[5] = {
+        {RANK_NINE, SUIT_HEARTS},
+        {RANK_NINE, SUIT_DIAMONDS},
+        {RANK_NINE, SUIT_CLUBS},
+        {RANK_NINE, SUIT_SPADES},
+        {RANK_TWO, SUIT_HEARTS}
+    };
+    Rank tiebreakers[3];
+    size_t num_tiebreakers = 0;
+
+    int result = detect_two_pair(cards, 5, NULL, tiebreakers, &num_tiebreakers);
+
+    assert(result == 0);
+    printf("  Pass: Four of a kind correctly identified as non-two-pair\n");
+}
+
+/* Test one pair (should NOT be two pair) */
+void test_one_pair_not_two_pair(void) {
+    printf("Testing one pair (not two pair)...\n");
+    Card cards[5] = {
+        {RANK_KING, SUIT_HEARTS},
+        {RANK_KING, SUIT_DIAMONDS},
+        {RANK_SEVEN, SUIT_CLUBS},
+        {RANK_JACK, SUIT_HEARTS},
+        {RANK_TWO, SUIT_DIAMONDS}
+    };
+    Rank tiebreakers[3];
+    size_t num_tiebreakers = 0;
+
+    int result = detect_two_pair(cards, 5, NULL, tiebreakers, &num_tiebreakers);
+
+    assert(result == 0);
+    printf("  Pass: One pair correctly identified as non-two-pair\n");
+}
+
+/* Test high card (no pairs) */
+void test_high_card_not_two_pair(void) {
+    printf("Testing high card (not two pair)...\n");
+    Card cards[5] = {
+        {RANK_TWO, SUIT_HEARTS},
+        {RANK_FIVE, SUIT_DIAMONDS},
+        {RANK_SEVEN, SUIT_CLUBS},
+        {RANK_JACK, SUIT_HEARTS},
+        {RANK_KING, SUIT_DIAMONDS}
+    };
+    Rank tiebreakers[3];
+    size_t num_tiebreakers = 0;
+
+    int result = detect_two_pair(cards, 5, NULL, tiebreakers, &num_tiebreakers);
+
+    assert(result == 0);
+    printf("  Pass: High card correctly identified as non-two-pair\n");
+}
+
+/* Test invalid input - NULL cards */
+void test_null_cards(void) {
+    printf("Testing NULL cards pointer...\n");
+    Rank tiebreakers[3];
+    size_t num_tiebreakers = 0;
+
+    int result = detect_two_pair(NULL, 5, NULL, tiebreakers, &num_tiebreakers);
+
+    assert(result == 0);
+    printf("  Pass: NULL cards handled correctly\n");
+}
+
+/* Test invalid input - wrong length */
+void test_invalid_length(void) {
+    printf("Testing invalid length (4 cards)...\n");
+    Card cards[4] = {
+        {RANK_ACE, SUIT_HEARTS},
+        {RANK_ACE, SUIT_DIAMONDS},
+        {RANK_KING, SUIT_CLUBS},
+        {RANK_KING, SUIT_SPADES}
+    };
+    Rank tiebreakers[3];
+    size_t num_tiebreakers = 0;
+
+    int result = detect_two_pair(cards, 4, NULL, tiebreakers, &num_tiebreakers);
+
+    assert(result == 0);
+    printf("  Pass: Invalid length handled correctly\n");
+}
+
+/* Test invalid input - NULL tiebreakers */
+void test_null_tiebreakers(void) {
+    printf("Testing NULL tiebreakers pointer...\n");
+    Card cards[5] = {
+        {RANK_ACE, SUIT_HEARTS},
+        {RANK_ACE, SUIT_DIAMONDS},
+        {RANK_KING, SUIT_CLUBS},
+        {RANK_KING, SUIT_SPADES},
+        {RANK_QUEEN, SUIT_HEARTS}
+    };
+    size_t num_tiebreakers = 0;
+
+    int result = detect_two_pair(cards, 5, NULL, NULL, &num_tiebreakers);
+
+    assert(result == 0);
+    printf("  Pass: NULL tiebreakers handled correctly\n");
+}
+
+/* Test invalid input - NULL num_tiebreakers */
+void test_null_num_tiebreakers(void) {
+    printf("Testing NULL num_tiebreakers pointer...\n");
+    Card cards[5] = {
+        {RANK_ACE, SUIT_HEARTS},
+        {RANK_ACE, SUIT_DIAMONDS},
+        {RANK_KING, SUIT_CLUBS},
+        {RANK_KING, SUIT_SPADES},
+        {RANK_QUEEN, SUIT_HEARTS}
+    };
+    Rank tiebreakers[3];
+
+    int result = detect_two_pair(cards, 5, NULL, tiebreakers, NULL);
+
+    assert(result == 0);
+    printf("  Pass: NULL num_tiebreakers handled correctly\n");
+}
+
+int main(void) {
+    printf("\n==========================================\n");
+    printf("Testing detect_two_pair function - Issue #29\n");
+    printf("==========================================\n\n");
+
+    test_two_pair_aces_kings_queen();
+    test_two_pair_tens_twos_ace();
+    test_two_pair_unordered();
+    test_two_pair_with_counts();
+    test_full_house_not_two_pair();
+    test_three_of_a_kind_not_two_pair();
+    test_four_of_a_kind_not_two_pair();
+    test_one_pair_not_two_pair();
+    test_high_card_not_two_pair();
+    test_null_cards();
+    test_invalid_length();
+    test_null_tiebreakers();
+    test_null_num_tiebreakers();
+
+    printf("\n==========================================\n");
+    printf("ALL TESTS PASSED!\n");
+    printf("==========================================\n");
+
+    return 0;
+}


### PR DESCRIPTION
## Summary

Implements the `detect_two_pair` function for poker hand evaluation as specified in issue #29.

### Changes Made

- **Function Declaration** (`include/poker.h:230-242`): Added detect_two_pair function signature with comprehensive documentation
- **Implementation** (`src/evaluator.c:451-536`): Implemented two pair detection logic following established patterns
- **Test Suite** (`tests/test_detect_two_pair.c`): Created 13 comprehensive test cases covering all scenarios

### Implementation Details

The function detects exactly 2 ranks with 2 cards each and returns tiebreakers as `[high_pair, low_pair, kicker]`:

- Validates all input parameters (NULL checks, length validation)
- Excludes full houses by checking for trips/quads (count >= 3)
- Finds exactly 2 pairs (count == 2)
- Sorts pairs in descending order (high pair first)
- Identifies kicker (count == 1)
- Handles optional pre-computed rank counts for performance

### Test Coverage

13 test cases validate:
- ✅ Valid two pair hands with correct tiebreaker ordering
- ✅ Unordered cards (verifies sorting)
- ✅ Pre-computed counts optimization path
- ✅ Exclusion of full house, trips, quads, one pair, high card
- ✅ Input validation (NULL pointers, invalid length)

All tests pass with no warnings.

### Quality Metrics

- **TDD Methodology**: Strict RED-GREEN-REFACTOR cycle followed
- **Time Complexity**: O(1) - constant 13 rank iterations
- **Space Complexity**: O(1) - fixed size local arrays
- **Code Style**: Compiles with -Wall -Wextra, follows C99 standard
- **Consistency**: Matches patterns from detect_three_of_a_kind and detect_full_house

Closes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)