### PR TITLE
[03.09] Implement detect_one_pair function

### DIFF
--- a/include/poker.h
+++ b/include/poker.h
@@ -242,6 +242,20 @@ int detect_two_pair(const Card* cards, size_t len,
                     size_t* out_num_tiebreakers);
 
 /**
+ * @brief Detect one pair
+ * @param cards Array of exactly 5 cards
+ * @param len Must be 5
+ * @param counts Optional pre-computed rank counts (can be NULL)
+ * @param out_tiebreakers Output array for tiebreaker ranks
+ * @param out_num_tiebreakers Pointer to receive count of tiebreakers
+ * @return 1 if one pair, 0 otherwise
+ */
+int detect_one_pair(const Card* cards, size_t len,
+                    const int* counts,
+                    Rank* out_tiebreakers,
+                    size_t* out_num_tiebreakers);
+
+/**
  * @brief Detect straight flush
  * @param cards Array of exactly 5 cards
  * @param len Must be 5

--- a/src/evaluator.c
+++ b/src/evaluator.c
@@ -535,6 +535,97 @@ int detect_two_pair(const Card* cards, size_t len,
     return 1;
 }
 
+/**
+ * @brief Detect one pair
+ *
+ * Detects if the hand contains exactly one pair (1 rank with 2 cards).
+ * Returns tiebreakers in the format: [pair_rank, kicker1, kicker2, kicker3]
+ * where kickers are sorted in descending order.
+ *
+ * The function validates all input parameters and handles the optional counts
+ * parameter by computing counts internally if NULL is provided. It excludes
+ * two pairs, trips, full houses, and quads.
+ *
+ * @param cards Array of exactly 5 cards
+ * @param len Must be 5
+ * @param counts Optional pre-computed rank counts (can be NULL)
+ * @param out_tiebreakers Output array for tiebreaker ranks
+ * @param out_num_tiebreakers Pointer to receive count of tiebreakers
+ * @return 1 if one pair, 0 otherwise
+ */
+int detect_one_pair(const Card* cards, size_t len,
+                    const int* counts,
+                    Rank* out_tiebreakers,
+                    size_t* out_num_tiebreakers) {
+    /* Validate input parameters */
+    if (cards == NULL || len != 5 || out_tiebreakers == NULL || out_num_tiebreakers == NULL) {
+        return 0;
+    }
+
+    /* Use provided counts or compute locally */
+    int local_counts[15];
+    const int* rank_count_array;
+
+    if (counts == NULL) {
+        rank_counts(cards, len, local_counts);
+        rank_count_array = local_counts;
+    } else {
+        rank_count_array = counts;
+    }
+
+    /* Check for trips or quads (count >= 3) - excludes full houses, trips, and quads */
+    for (int rank = RANK_TWO; rank <= RANK_ACE; rank++) {
+        if (rank_count_array[rank] >= 3) {
+            return 0;
+        }
+    }
+
+    /* Find exactly 1 rank with count == 2 (pair) */
+    Rank pair_rank = 0;
+    int pair_count = 0;
+
+    for (int rank = RANK_TWO; rank <= RANK_ACE; rank++) {
+        if (rank_count_array[rank] == 2) {
+            pair_rank = (Rank)rank;
+            pair_count++;
+        }
+    }
+
+    /* Must have exactly 1 pair */
+    if (pair_count != 1) {
+        return 0;
+    }
+
+    /* Find exactly 3 kickers (count == 1) */
+    Rank kickers[3];
+    int kicker_count = 0;
+
+    for (int rank = RANK_TWO; rank <= RANK_ACE; rank++) {
+        if (rank_count_array[rank] == 1) {
+            if (kicker_count < 3) {
+                kickers[kicker_count++] = (Rank)rank;
+            }
+        }
+    }
+
+    /* Should have exactly 3 kickers */
+    if (kicker_count != 3) {
+        return 0;
+    }
+
+    /* Sort kickers in descending order */
+    qsort(kickers, 3, sizeof(Rank), rank_compare_desc);
+
+    /* Write tiebreakers: [pair_rank, kicker1, kicker2, kicker3] */
+    out_tiebreakers[0] = pair_rank;
+    out_tiebreakers[1] = kickers[0];  /* Highest kicker */
+    out_tiebreakers[2] = kickers[1];  /* Middle kicker */
+    out_tiebreakers[3] = kickers[2];  /* Lowest kicker */
+    *out_num_tiebreakers = 4;
+
+    return 1;
+}
+
 int evaluate_hand(void) {
     /* Placeholder for hand evaluation */
     return 0;

--- a/tests/test_detect_one_pair.c
+++ b/tests/test_detect_one_pair.c
@@ -1,0 +1,296 @@
+#include <assert.h>
+#include <stdio.h>
+#include "../include/poker.h"
+
+/*
+ * Test Suite for detect_one_pair function
+ * Tests verify one pair detection (exactly 1 rank with 2 cards)
+ */
+
+/* Test one pair: Aces with King-Queen-Jack kickers */
+void test_one_pair_aces_kqj(void) {
+    printf("Testing one pair: Aces with K-Q-J kickers...\n");
+    Card cards[5] = {
+        {RANK_ACE, SUIT_HEARTS},
+        {RANK_ACE, SUIT_DIAMONDS},
+        {RANK_KING, SUIT_CLUBS},
+        {RANK_QUEEN, SUIT_SPADES},
+        {RANK_JACK, SUIT_HEARTS}
+    };
+    Rank tiebreakers[4];
+    size_t num_tiebreakers = 0;
+
+    int result = detect_one_pair(cards, 5, NULL, tiebreakers, &num_tiebreakers);
+
+    assert(result == 1);
+    assert(num_tiebreakers == 4);
+    assert(tiebreakers[0] == RANK_ACE);   /* Pair rank */
+    assert(tiebreakers[1] == RANK_KING);  /* Kicker 1 */
+    assert(tiebreakers[2] == RANK_QUEEN); /* Kicker 2 */
+    assert(tiebreakers[3] == RANK_JACK);  /* Kicker 3 */
+    printf("  Pass: One pair Aces with K-Q-J kickers detected correctly\n");
+}
+
+/* Test one pair: Twos with Ace-King-Queen kickers */
+void test_one_pair_twos_akq(void) {
+    printf("Testing one pair: Twos with A-K-Q kickers...\n");
+    Card cards[5] = {
+        {RANK_TWO, SUIT_HEARTS},
+        {RANK_TWO, SUIT_DIAMONDS},
+        {RANK_ACE, SUIT_CLUBS},
+        {RANK_KING, SUIT_SPADES},
+        {RANK_QUEEN, SUIT_HEARTS}
+    };
+    Rank tiebreakers[4];
+    size_t num_tiebreakers = 0;
+
+    int result = detect_one_pair(cards, 5, NULL, tiebreakers, &num_tiebreakers);
+
+    assert(result == 1);
+    assert(num_tiebreakers == 4);
+    assert(tiebreakers[0] == RANK_TWO);   /* Pair rank */
+    assert(tiebreakers[1] == RANK_ACE);   /* Kicker 1 (highest) */
+    assert(tiebreakers[2] == RANK_KING);  /* Kicker 2 */
+    assert(tiebreakers[3] == RANK_QUEEN); /* Kicker 3 */
+    printf("  Pass: One pair Twos with A-K-Q kickers detected correctly\n");
+}
+
+/* Test one pair with unordered cards (test kicker sorting) */
+void test_one_pair_unordered(void) {
+    printf("Testing one pair with unordered cards...\n");
+    Card cards[5] = {
+        {RANK_FIVE, SUIT_HEARTS},
+        {RANK_JACK, SUIT_DIAMONDS},
+        {RANK_THREE, SUIT_CLUBS},
+        {RANK_JACK, SUIT_SPADES},
+        {RANK_SEVEN, SUIT_HEARTS}
+    };
+    Rank tiebreakers[4];
+    size_t num_tiebreakers = 0;
+
+    int result = detect_one_pair(cards, 5, NULL, tiebreakers, &num_tiebreakers);
+
+    assert(result == 1);
+    assert(num_tiebreakers == 4);
+    assert(tiebreakers[0] == RANK_JACK);  /* Pair rank */
+    assert(tiebreakers[1] == RANK_SEVEN); /* Highest kicker */
+    assert(tiebreakers[2] == RANK_FIVE);  /* Middle kicker */
+    assert(tiebreakers[3] == RANK_THREE); /* Lowest kicker */
+    printf("  Pass: One pair with unordered cards sorted correctly\n");
+}
+
+/* Test one pair with pre-computed counts */
+void test_one_pair_with_counts(void) {
+    printf("Testing one pair with pre-computed counts...\n");
+    Card cards[5] = {
+        {RANK_NINE, SUIT_HEARTS},
+        {RANK_NINE, SUIT_DIAMONDS},
+        {RANK_FOUR, SUIT_CLUBS},
+        {RANK_EIGHT, SUIT_SPADES},
+        {RANK_SIX, SUIT_HEARTS}
+    };
+
+    /* Pre-compute rank counts */
+    int counts[15];
+    rank_counts(cards, 5, counts);
+
+    Rank tiebreakers[4];
+    size_t num_tiebreakers = 0;
+
+    int result = detect_one_pair(cards, 5, counts, tiebreakers, &num_tiebreakers);
+
+    assert(result == 1);
+    assert(num_tiebreakers == 4);
+    assert(tiebreakers[0] == RANK_NINE);
+    assert(tiebreakers[1] == RANK_EIGHT);
+    assert(tiebreakers[2] == RANK_SIX);
+    assert(tiebreakers[3] == RANK_FOUR);
+    printf("  Pass: One pair with pre-computed counts detected correctly\n");
+}
+
+/* Test two pair (should NOT be one pair) */
+void test_two_pair_not_one_pair(void) {
+    printf("Testing two pair (not one pair)...\n");
+    Card cards[5] = {
+        {RANK_ACE, SUIT_HEARTS},
+        {RANK_ACE, SUIT_DIAMONDS},
+        {RANK_KING, SUIT_CLUBS},
+        {RANK_KING, SUIT_SPADES},
+        {RANK_QUEEN, SUIT_HEARTS}
+    };
+    Rank tiebreakers[4];
+    size_t num_tiebreakers = 0;
+
+    int result = detect_one_pair(cards, 5, NULL, tiebreakers, &num_tiebreakers);
+
+    assert(result == 0);
+    printf("  Pass: Two pair correctly identified as non-one-pair\n");
+}
+
+/* Test three of a kind (should NOT be one pair) */
+void test_three_of_a_kind_not_one_pair(void) {
+    printf("Testing three of a kind (not one pair)...\n");
+    Card cards[5] = {
+        {RANK_EIGHT, SUIT_HEARTS},
+        {RANK_EIGHT, SUIT_DIAMONDS},
+        {RANK_EIGHT, SUIT_CLUBS},
+        {RANK_KING, SUIT_HEARTS},
+        {RANK_QUEEN, SUIT_DIAMONDS}
+    };
+    Rank tiebreakers[4];
+    size_t num_tiebreakers = 0;
+
+    int result = detect_one_pair(cards, 5, NULL, tiebreakers, &num_tiebreakers);
+
+    assert(result == 0);
+    printf("  Pass: Three of a kind correctly identified as non-one-pair\n");
+}
+
+/* Test full house (should NOT be one pair) */
+void test_full_house_not_one_pair(void) {
+    printf("Testing full house (not one pair)...\n");
+    Card cards[5] = {
+        {RANK_JACK, SUIT_HEARTS},
+        {RANK_JACK, SUIT_DIAMONDS},
+        {RANK_JACK, SUIT_CLUBS},
+        {RANK_TWO, SUIT_HEARTS},
+        {RANK_TWO, SUIT_DIAMONDS}
+    };
+    Rank tiebreakers[4];
+    size_t num_tiebreakers = 0;
+
+    int result = detect_one_pair(cards, 5, NULL, tiebreakers, &num_tiebreakers);
+
+    assert(result == 0);
+    printf("  Pass: Full house correctly identified as non-one-pair\n");
+}
+
+/* Test four of a kind (should NOT be one pair) */
+void test_four_of_a_kind_not_one_pair(void) {
+    printf("Testing four of a kind (not one pair)...\n");
+    Card cards[5] = {
+        {RANK_NINE, SUIT_HEARTS},
+        {RANK_NINE, SUIT_DIAMONDS},
+        {RANK_NINE, SUIT_CLUBS},
+        {RANK_NINE, SUIT_SPADES},
+        {RANK_TWO, SUIT_HEARTS}
+    };
+    Rank tiebreakers[4];
+    size_t num_tiebreakers = 0;
+
+    int result = detect_one_pair(cards, 5, NULL, tiebreakers, &num_tiebreakers);
+
+    assert(result == 0);
+    printf("  Pass: Four of a kind correctly identified as non-one-pair\n");
+}
+
+/* Test high card (no pairs) */
+void test_high_card_not_one_pair(void) {
+    printf("Testing high card (not one pair)...\n");
+    Card cards[5] = {
+        {RANK_TWO, SUIT_HEARTS},
+        {RANK_FIVE, SUIT_DIAMONDS},
+        {RANK_SEVEN, SUIT_CLUBS},
+        {RANK_JACK, SUIT_HEARTS},
+        {RANK_KING, SUIT_DIAMONDS}
+    };
+    Rank tiebreakers[4];
+    size_t num_tiebreakers = 0;
+
+    int result = detect_one_pair(cards, 5, NULL, tiebreakers, &num_tiebreakers);
+
+    assert(result == 0);
+    printf("  Pass: High card correctly identified as non-one-pair\n");
+}
+
+/* Test invalid input - NULL cards */
+void test_null_cards(void) {
+    printf("Testing NULL cards pointer...\n");
+    Rank tiebreakers[4];
+    size_t num_tiebreakers = 0;
+
+    int result = detect_one_pair(NULL, 5, NULL, tiebreakers, &num_tiebreakers);
+
+    assert(result == 0);
+    printf("  Pass: NULL cards handled correctly\n");
+}
+
+/* Test invalid input - wrong length */
+void test_invalid_length(void) {
+    printf("Testing invalid length (4 cards)...\n");
+    Card cards[4] = {
+        {RANK_ACE, SUIT_HEARTS},
+        {RANK_ACE, SUIT_DIAMONDS},
+        {RANK_KING, SUIT_CLUBS},
+        {RANK_QUEEN, SUIT_SPADES}
+    };
+    Rank tiebreakers[4];
+    size_t num_tiebreakers = 0;
+
+    int result = detect_one_pair(cards, 4, NULL, tiebreakers, &num_tiebreakers);
+
+    assert(result == 0);
+    printf("  Pass: Invalid length handled correctly\n");
+}
+
+/* Test invalid input - NULL tiebreakers */
+void test_null_tiebreakers(void) {
+    printf("Testing NULL tiebreakers pointer...\n");
+    Card cards[5] = {
+        {RANK_ACE, SUIT_HEARTS},
+        {RANK_ACE, SUIT_DIAMONDS},
+        {RANK_KING, SUIT_CLUBS},
+        {RANK_QUEEN, SUIT_SPADES},
+        {RANK_JACK, SUIT_HEARTS}
+    };
+    size_t num_tiebreakers = 0;
+
+    int result = detect_one_pair(cards, 5, NULL, NULL, &num_tiebreakers);
+
+    assert(result == 0);
+    printf("  Pass: NULL tiebreakers handled correctly\n");
+}
+
+/* Test invalid input - NULL num_tiebreakers */
+void test_null_num_tiebreakers(void) {
+    printf("Testing NULL num_tiebreakers pointer...\n");
+    Card cards[5] = {
+        {RANK_ACE, SUIT_HEARTS},
+        {RANK_ACE, SUIT_DIAMONDS},
+        {RANK_KING, SUIT_CLUBS},
+        {RANK_QUEEN, SUIT_SPADES},
+        {RANK_JACK, SUIT_HEARTS}
+    };
+    Rank tiebreakers[4];
+
+    int result = detect_one_pair(cards, 5, NULL, tiebreakers, NULL);
+
+    assert(result == 0);
+    printf("  Pass: NULL num_tiebreakers handled correctly\n");
+}
+
+int main(void) {
+    printf("\n==========================================\n");
+    printf("Testing detect_one_pair function - Issue #30\n");
+    printf("==========================================\n\n");
+
+    test_one_pair_aces_kqj();
+    test_one_pair_twos_akq();
+    test_one_pair_unordered();
+    test_one_pair_with_counts();
+    test_two_pair_not_one_pair();
+    test_three_of_a_kind_not_one_pair();
+    test_full_house_not_one_pair();
+    test_four_of_a_kind_not_one_pair();
+    test_high_card_not_one_pair();
+    test_null_cards();
+    test_invalid_length();
+    test_null_tiebreakers();
+    test_null_num_tiebreakers();
+
+    printf("\n==========================================\n");
+    printf("ALL TESTS PASSED!\n");
+    printf("==========================================\n");
+
+    return 0;
+}


### PR DESCRIPTION
## Summary
Implements the `detect_one_pair` function for poker hand evaluation as specified in issue #30.

- Detects exactly 1 rank with 2 cards (one pair)
- Excludes two pair, three of a kind, full house, and four of a kind
- Returns pair rank followed by 3 kickers in descending order
- Validates all input parameters with comprehensive error handling
- Supports optional pre-computed rank counts for efficiency

## Test Coverage
All 13 test cases pass:
- One pair detection with various ranks (Aces, Twos, Jacks)
- Kicker sorting in descending order (unordered input)
- Pre-computed rank counts support
- Exclusion of higher hands (two pair, trips, full house, quads)
- Exclusion of lower hands (high card)
- Input validation (NULL pointers, invalid length)

## Implementation Details
- Uses `rank_counts()` helper to count card frequencies
- Validates exactly 1 pair (count == 2) and 3 kickers (count == 1)
- Sorts kickers using `qsort()` with `rank_compare_desc()`
- Returns tiebreakers: `[pair_rank, kicker1, kicker2, kicker3]`
- Sets `*out_num_tiebreakers = 4`

## Files Changed
- `include/poker.h`: Added function declaration with documentation
- `src/evaluator.c`: Implemented `detect_one_pair()` function
- `tests/test_detect_one_pair.c`: Comprehensive test suite (13 test cases)

Closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)