### PR TITLE
[03.10] Implement detect_high_card function

### DIFF
--- a/include/poker.h
+++ b/include/poker.h
@@ -282,6 +282,18 @@ int detect_straight(const Card* cards, size_t len,
                     Rank* out_tiebreakers,
                     size_t* out_num_tiebreakers);
 
+/**
+ * @brief Detect high card (always succeeds for valid input)
+ * @param cards Array of exactly 5 cards
+ * @param len Must be 5
+ * @param out_tiebreakers Output array for tiebreaker ranks
+ * @param out_num_tiebreakers Pointer to receive count of tiebreakers
+ * @return 1 if valid 5-card input, 0 otherwise
+ */
+int detect_high_card(const Card* cards, size_t len,
+                     Rank* out_tiebreakers,
+                     size_t* out_num_tiebreakers);
+
 /*
  * Maximum number of tiebreaker ranks in Hand struct
  */

--- a/src/evaluator.c
+++ b/src/evaluator.c
@@ -630,3 +630,44 @@ int detect_straight(const Card* cards, size_t len,
 
     return 1;
 }
+
+/**
+ * @brief Detect high card (always succeeds for valid input)
+ *
+ * Detects high card, which is the fallback when no other hand category matches.
+ * Returns all 5 card ranks in descending order as tiebreakers. This function
+ * always succeeds for valid 5-card input, making it the default/weakest hand.
+ *
+ * @param cards Array of exactly 5 cards
+ * @param len Must be 5
+ * @param out_tiebreakers Output array for tiebreaker ranks
+ * @param out_num_tiebreakers Pointer to receive count of tiebreakers
+ * @return 1 if valid 5-card input, 0 otherwise
+ */
+int detect_high_card(const Card* cards, size_t len,
+                     Rank* out_tiebreakers,
+                     size_t* out_num_tiebreakers) {
+    /* Validate input parameters */
+    if (cards == NULL || len != 5 || out_tiebreakers == NULL || out_num_tiebreakers == NULL) {
+        return 0;
+    }
+
+    /* Extract ranks into array */
+    Rank ranks[5];
+    for (size_t i = 0; i < 5; i++) {
+        ranks[i] = (Rank)cards[i].rank;
+    }
+
+    /* Sort ranks in descending order */
+    qsort(ranks, 5, sizeof(Rank), rank_compare_desc);
+
+    /* Write all 5 ranks to tiebreakers */
+    for (size_t i = 0; i < 5; i++) {
+        out_tiebreakers[i] = ranks[i];
+    }
+
+    /* Set number of tiebreakers to 5 */
+    *out_num_tiebreakers = 5;
+
+    return 1;
+}

--- a/tests/test_detect_high_card.c
+++ b/tests/test_detect_high_card.c
@@ -1,0 +1,253 @@
+#include <assert.h>
+#include <stdio.h>
+#include <string.h>
+#include "../include/poker.h"
+
+/*
+ * Test Suite for detect_high_card function
+ * Tests verify high card detection (fallback when no other category matches)
+ */
+
+/* Test high card with Ace-high */
+void test_high_card_ace_high(void) {
+    printf("Testing high card with Ace-high...\n");
+    Card cards[5] = {
+        {RANK_ACE, SUIT_HEARTS},
+        {RANK_KING, SUIT_DIAMONDS},
+        {RANK_QUEEN, SUIT_CLUBS},
+        {RANK_JACK, SUIT_SPADES},
+        {RANK_NINE, SUIT_HEARTS}
+    };
+    Rank tiebreakers[5];
+    size_t num_tiebreakers;
+    int result = detect_high_card(cards, 5, tiebreakers, &num_tiebreakers);
+    assert(result == 1);
+    assert(num_tiebreakers == 5);
+    /* Tiebreakers should be in descending order: A K Q J 9 */
+    assert(tiebreakers[0] == RANK_ACE);
+    assert(tiebreakers[1] == RANK_KING);
+    assert(tiebreakers[2] == RANK_QUEEN);
+    assert(tiebreakers[3] == RANK_JACK);
+    assert(tiebreakers[4] == RANK_NINE);
+    printf("  Pass: Ace-high detected with correct tiebreakers\n");
+}
+
+/* Test high card with King-high */
+void test_high_card_king_high(void) {
+    printf("Testing high card with King-high...\n");
+    Card cards[5] = {
+        {RANK_KING, SUIT_HEARTS},
+        {RANK_TEN, SUIT_DIAMONDS},
+        {RANK_EIGHT, SUIT_CLUBS},
+        {RANK_SIX, SUIT_SPADES},
+        {RANK_FOUR, SUIT_HEARTS}
+    };
+    Rank tiebreakers[5];
+    size_t num_tiebreakers;
+    int result = detect_high_card(cards, 5, tiebreakers, &num_tiebreakers);
+    assert(result == 1);
+    assert(num_tiebreakers == 5);
+    /* Tiebreakers should be in descending order: K 10 8 6 4 */
+    assert(tiebreakers[0] == RANK_KING);
+    assert(tiebreakers[1] == RANK_TEN);
+    assert(tiebreakers[2] == RANK_EIGHT);
+    assert(tiebreakers[3] == RANK_SIX);
+    assert(tiebreakers[4] == RANK_FOUR);
+    printf("  Pass: King-high detected with correct tiebreakers\n");
+}
+
+/* Test high card with unordered cards */
+void test_high_card_unordered(void) {
+    printf("Testing high card with unordered cards...\n");
+    Card cards[5] = {
+        {RANK_THREE, SUIT_HEARTS},
+        {RANK_QUEEN, SUIT_DIAMONDS},
+        {RANK_SEVEN, SUIT_CLUBS},
+        {RANK_ACE, SUIT_SPADES},
+        {RANK_NINE, SUIT_HEARTS}
+    };
+    Rank tiebreakers[5];
+    size_t num_tiebreakers;
+    int result = detect_high_card(cards, 5, tiebreakers, &num_tiebreakers);
+    assert(result == 1);
+    assert(num_tiebreakers == 5);
+    /* Should be sorted descending regardless of input order: A Q 9 7 3 */
+    assert(tiebreakers[0] == RANK_ACE);
+    assert(tiebreakers[1] == RANK_QUEEN);
+    assert(tiebreakers[2] == RANK_NINE);
+    assert(tiebreakers[3] == RANK_SEVEN);
+    assert(tiebreakers[4] == RANK_THREE);
+    printf("  Pass: Unordered cards detected and sorted correctly\n");
+}
+
+/* Test high card with low cards */
+void test_high_card_low_cards(void) {
+    printf("Testing high card with low cards...\n");
+    Card cards[5] = {
+        {RANK_SEVEN, SUIT_HEARTS},
+        {RANK_FIVE, SUIT_DIAMONDS},
+        {RANK_FOUR, SUIT_CLUBS},
+        {RANK_THREE, SUIT_SPADES},
+        {RANK_TWO, SUIT_HEARTS}
+    };
+    Rank tiebreakers[5];
+    size_t num_tiebreakers;
+    int result = detect_high_card(cards, 5, tiebreakers, &num_tiebreakers);
+    assert(result == 1);
+    assert(num_tiebreakers == 5);
+    /* Tiebreakers should be: 7 5 4 3 2 */
+    assert(tiebreakers[0] == RANK_SEVEN);
+    assert(tiebreakers[1] == RANK_FIVE);
+    assert(tiebreakers[2] == RANK_FOUR);
+    assert(tiebreakers[3] == RANK_THREE);
+    assert(tiebreakers[4] == RANK_TWO);
+    printf("  Pass: Low cards detected with correct tiebreakers\n");
+}
+
+/* Test high card with all face cards except suited */
+void test_high_card_mixed_suits(void) {
+    printf("Testing high card with mixed suits...\n");
+    Card cards[5] = {
+        {RANK_ACE, SUIT_HEARTS},
+        {RANK_KING, SUIT_DIAMONDS},
+        {RANK_QUEEN, SUIT_CLUBS},
+        {RANK_JACK, SUIT_SPADES},
+        {RANK_TEN, SUIT_HEARTS}
+    };
+    Rank tiebreakers[5];
+    size_t num_tiebreakers;
+    int result = detect_high_card(cards, 5, tiebreakers, &num_tiebreakers);
+    assert(result == 1);
+    assert(num_tiebreakers == 5);
+    /* Tiebreakers should be: A K Q J 10 */
+    assert(tiebreakers[0] == RANK_ACE);
+    assert(tiebreakers[1] == RANK_KING);
+    assert(tiebreakers[2] == RANK_QUEEN);
+    assert(tiebreakers[3] == RANK_JACK);
+    assert(tiebreakers[4] == RANK_TEN);
+    printf("  Pass: Mixed suits detected with correct tiebreakers\n");
+}
+
+/* Test invalid input - wrong length (4 cards) */
+void test_invalid_length_too_few(void) {
+    printf("Testing invalid length (4 cards)...\n");
+    Card cards[4] = {
+        {RANK_ACE, SUIT_HEARTS},
+        {RANK_KING, SUIT_DIAMONDS},
+        {RANK_QUEEN, SUIT_CLUBS},
+        {RANK_JACK, SUIT_SPADES}
+    };
+    Rank tiebreakers[5];
+    size_t num_tiebreakers;
+    int result = detect_high_card(cards, 4, tiebreakers, &num_tiebreakers);
+    assert(result == 0);
+    printf("  Pass: Invalid length (4 cards) handled correctly\n");
+}
+
+/* Test invalid input - wrong length (6 cards) */
+void test_invalid_length_too_many(void) {
+    printf("Testing invalid length (6 cards)...\n");
+    Card cards[6] = {
+        {RANK_ACE, SUIT_HEARTS},
+        {RANK_KING, SUIT_DIAMONDS},
+        {RANK_QUEEN, SUIT_CLUBS},
+        {RANK_JACK, SUIT_SPADES},
+        {RANK_TEN, SUIT_HEARTS},
+        {RANK_NINE, SUIT_DIAMONDS}
+    };
+    Rank tiebreakers[5];
+    size_t num_tiebreakers;
+    int result = detect_high_card(cards, 6, tiebreakers, &num_tiebreakers);
+    assert(result == 0);
+    printf("  Pass: Invalid length (6 cards) handled correctly\n");
+}
+
+/* Test invalid input - NULL cards */
+void test_null_cards(void) {
+    printf("Testing NULL cards pointer...\n");
+    Rank tiebreakers[5];
+    size_t num_tiebreakers;
+    int result = detect_high_card(NULL, 5, tiebreakers, &num_tiebreakers);
+    assert(result == 0);
+    printf("  Pass: NULL cards handled correctly\n");
+}
+
+/* Test invalid input - NULL tiebreakers */
+void test_null_tiebreakers(void) {
+    printf("Testing NULL tiebreakers pointer...\n");
+    Card cards[5] = {
+        {RANK_ACE, SUIT_HEARTS},
+        {RANK_KING, SUIT_DIAMONDS},
+        {RANK_QUEEN, SUIT_CLUBS},
+        {RANK_JACK, SUIT_SPADES},
+        {RANK_TEN, SUIT_HEARTS}
+    };
+    size_t num_tiebreakers;
+    int result = detect_high_card(cards, 5, NULL, &num_tiebreakers);
+    assert(result == 0);
+    printf("  Pass: NULL tiebreakers handled correctly\n");
+}
+
+/* Test invalid input - NULL num_tiebreakers */
+void test_null_num_tiebreakers(void) {
+    printf("Testing NULL num_tiebreakers pointer...\n");
+    Card cards[5] = {
+        {RANK_ACE, SUIT_HEARTS},
+        {RANK_KING, SUIT_DIAMONDS},
+        {RANK_QUEEN, SUIT_CLUBS},
+        {RANK_JACK, SUIT_SPADES},
+        {RANK_TEN, SUIT_HEARTS}
+    };
+    Rank tiebreakers[5];
+    int result = detect_high_card(cards, 5, tiebreakers, NULL);
+    assert(result == 0);
+    printf("  Pass: NULL num_tiebreakers handled correctly\n");
+}
+
+/* Test high card with duplicate ranks (should still work - extracts all 5 ranks) */
+void test_high_card_with_pair(void) {
+    printf("Testing high card with pair (should still extract 5 ranks)...\n");
+    Card cards[5] = {
+        {RANK_ACE, SUIT_HEARTS},
+        {RANK_ACE, SUIT_DIAMONDS},
+        {RANK_QUEEN, SUIT_CLUBS},
+        {RANK_JACK, SUIT_SPADES},
+        {RANK_TEN, SUIT_HEARTS}
+    };
+    Rank tiebreakers[5];
+    size_t num_tiebreakers;
+    int result = detect_high_card(cards, 5, tiebreakers, &num_tiebreakers);
+    assert(result == 1);
+    assert(num_tiebreakers == 5);
+    /* Should extract all 5 ranks in descending order: A A Q J 10 */
+    assert(tiebreakers[0] == RANK_ACE);
+    assert(tiebreakers[1] == RANK_ACE);
+    assert(tiebreakers[2] == RANK_QUEEN);
+    assert(tiebreakers[3] == RANK_JACK);
+    assert(tiebreakers[4] == RANK_TEN);
+    printf("  Pass: Pair handled - all 5 ranks extracted\n");
+}
+
+int main(void) {
+    printf("\n==========================================\n");
+    printf("Testing detect_high_card function - Issue #31\n");
+    printf("==========================================\n\n");
+
+    test_high_card_ace_high();
+    test_high_card_king_high();
+    test_high_card_unordered();
+    test_high_card_low_cards();
+    test_high_card_mixed_suits();
+    test_invalid_length_too_few();
+    test_invalid_length_too_many();
+    test_null_cards();
+    test_null_tiebreakers();
+    test_null_num_tiebreakers();
+    test_high_card_with_pair();
+
+    printf("\n==========================================\n");
+    printf("ALL TESTS PASSED!\n");
+    printf("==========================================\n");
+
+    return 0;
+}


### PR DESCRIPTION
This PR implements the `detect_high_card` function for detecting high card hands (fallback when no other category matches).

## Changes
- Added `detect_high_card()` declaration to `include/poker.h` (lines 286-295)
- Implemented `detect_high_card()` in `src/evaluator.c` (lines 634-673)
- Added comprehensive test suite in `tests/test_detect_high_card.c` with 11 test cases

## Implementation Details
- Validates input parameters (returns 0 if len != 5 or NULL pointers)
- Extracts all 5 card ranks into an array
- Sorts ranks in descending order using qsort with rank_compare_desc helper
- Writes all 5 ranks to tiebreakers array
- Sets `*out_num_tiebreakers = 5`
- Always succeeds for valid 5-card input (returns 1)

## Test Coverage
The test suite verifies:
- Ace-high hands with correct rank ordering
- King-high hands with correct rank ordering
- Unordered input cards (verifies sorting works)
- Low card hands (2-7)
- Mixed suits handling
- Invalid input: len != 5 (too few, too many)
- Invalid input: NULL cards pointer
- Invalid input: NULL tiebreakers pointer
- Invalid input: NULL num_tiebreakers pointer
- Edge case: Pair in hand (still extracts all 5 ranks)

All 11 tests pass successfully.

Closes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>