### PR TITLE
[07.02] Add code coverage reporting to Makefile

### DIFF
--- a/README.md
+++ b/README.md
@@ -665,6 +665,101 @@ Fuzzing helps prevent:
 - AddressSanitizer: https://clang.llvm.org/docs/AddressSanitizer.html
 - Fuzzing best practices: https://google.github.io/fuzzing/
 
+## Code Coverage
+
+This project uses gcov and lcov to track test coverage and ensure comprehensive testing of all source code.
+
+### Current Coverage
+
+- **Overall**: 96.38% line coverage across all source files
+- **card.c**: 93.33% (60 lines)
+- **deck.c**: 92.50% (40 lines)
+- **evaluator.c**: 97.68% (259 lines)
+
+The project maintains a minimum coverage target of ≥90% to ensure code quality and reliability.
+
+### Generating Coverage Reports
+
+Generate coverage reports with a single command:
+
+```bash
+make coverage
+```
+
+This command:
+1. Rebuilds the library with coverage instrumentation (`--coverage` flag)
+2. Runs all test executables to collect coverage data
+3. Generates `.gcov` files showing line-by-line coverage
+4. Creates HTML report (if lcov is installed)
+
+### Viewing Coverage Results
+
+**Text-based coverage (always available):**
+```bash
+# View coverage summary
+cat *.gcov | grep -E "^(File|Lines executed|Creating)"
+
+# View detailed line coverage for a specific file
+cat card.c.gcov | less
+```
+
+**HTML coverage report (requires lcov):**
+```bash
+# Install lcov (one-time setup)
+sudo apt-get install lcov
+
+# Generate and view HTML report
+make coverage
+firefox coverage/index.html
+```
+
+The HTML report provides:
+- Interactive file browser with color-coded coverage
+- Line-by-line execution counts
+- Branch coverage visualization
+- Sortable coverage tables
+
+### Coverage Files
+
+The coverage target generates these artifacts:
+- `*.gcov` - Line-by-line coverage data for each source file
+- `coverage.info` - Aggregated coverage data (lcov format)
+- `coverage/` - HTML coverage report directory
+
+All coverage artifacts are ignored by git (see `.gitignore`).
+
+### Interpreting Coverage Results
+
+Each `.gcov` file shows:
+- Execution counts for each line (number on the left)
+- `#####` for lines that were never executed
+- `-` for non-executable lines (comments, declarations)
+
+**Example:**
+```
+        -:   10:/* Returns 1 if flush, 0 otherwise */
+       42:   11:int is_flush(const Card* cards, size_t len) {
+       42:   12:    if (len != 5) return 0;
+       40:   13:    Suit first = cards[0].suit;
+    #####:   14:    for (size_t i = 1; i < len; i++) {
+```
+
+This shows line 14 was never executed (likely unreachable code or edge case).
+
+### Coverage in CI/CD
+
+The coverage target is designed for integration with continuous integration:
+
+```bash
+# Run coverage and verify target met
+make coverage
+if grep -q "Lines executed:[0-9.]*% of" *.gcov; then
+    echo "Coverage target met"
+else
+    echo "Coverage below target" && exit 1
+fi
+```
+
 ## Status
 
 ✅ **Phase 00 Complete** - Project structure, build system, and documentation framework established


### PR DESCRIPTION
## Summary

This PR adds comprehensive code coverage reporting infrastructure using gcov and lcov, enabling developers to track test coverage and maintain high code quality standards.

## Changes

### Makefile
- Added `coverage` target that builds library with `--coverage` flag
- Runs all test executables to collect coverage data
- Generates `.gcov` files for line-by-line coverage analysis
- Creates HTML coverage report using lcov (if installed)
- Updated `clean` target to remove coverage artifacts
- Updated `help` target to document coverage command

### README.md
- Added comprehensive "Code Coverage" section with:
  - Current coverage metrics (96.38% overall)
  - Usage instructions for generating reports
  - Documentation for viewing text-based and HTML reports
  - Explanation of coverage file formats
  - CI/CD integration examples

### Coverage Results
- **Overall**: 96.38% line coverage (exceeds ≥90% target)
- **card.c**: 93.33% (60 lines)
- **deck.c**: 92.50% (40 lines)
- **evaluator.c**: 97.68% (259 lines)

## Usage

```bash
# Generate coverage report
make coverage

# View HTML report (if lcov installed)
firefox coverage/index.html

# View text-based coverage
cat *.gcov | grep -E "^(File|Lines executed)"
```

## Testing

Verified that:
- Coverage target builds successfully
- All 19 test executables run correctly
- .gcov files are generated with accurate line coverage
- Coverage exceeds 90% target across all source files
- Coverage artifacts are properly cleaned by `make clean`
- .gitignore excludes coverage files from git

## Acceptance Criteria

- [x] Add coverage CFLAGS: `--coverage` (enables gcov)
- [x] Create `coverage` target in Makefile
- [x] Generate `.gcov` files for all source files
- [x] Use lcov to create HTML report in `coverage/` directory
- [x] Add `coverage/` to `.gitignore` (already existed)
- [x] Document coverage usage in README
- [x] Target: Achieve ≥90% line coverage (achieved 96.38%)

Closes #87

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>