### PR TITLE
fix: add explicit permissions to CI workflow jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,8 @@ jobs:
   build-gcc:
     name: Build with GCC
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout code
@@ -31,6 +33,8 @@ jobs:
   lint:
     name: Static Analysis (cppcheck)
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout code
@@ -50,6 +54,8 @@ jobs:
   build-clang:
     name: Build with Clang
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout code
@@ -74,6 +80,8 @@ jobs:
     name: Run Test Suite
     runs-on: ubuntu-latest
     needs: build-gcc
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout code
@@ -97,6 +105,8 @@ jobs:
     name: Valgrind Memory Checks
     runs-on: ubuntu-latest
     needs: build-gcc
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout code
@@ -120,6 +130,9 @@ jobs:
     name: Code Coverage Report
     runs-on: ubuntu-latest
     needs: build-gcc
+    permissions:
+      contents: read
+      actions: write
 
     steps:
       - name: Checkout code
@@ -156,6 +169,8 @@ jobs:
     name: Fuzzing Tests
     runs-on: ubuntu-latest
     needs: build-gcc
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout code
@@ -190,6 +205,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build-gcc, build-clang, lint, test, valgrind, coverage, fuzzing]
     if: always()
+    permissions:
+      contents: read
+      actions: read
 
     steps:
       - name: Check build status


### PR DESCRIPTION
## Summary

Resolves 8 CodeQL security alerts by adding explicit `permissions:` blocks to all GitHub Actions workflow jobs.

## Changes

Added least-privilege permissions to 8 jobs in `.github/workflows/ci.yml`:

- **build-gcc, lint, build-clang, test, valgrind, fuzzing**: `contents: read`
- **coverage**: `contents: read`, `actions: write` (for artifact upload)
- **build-status**: `contents: read`, `actions: read` (for checking job statuses)

## Security Impact

**Before**: Jobs inherited repository-wide permissions (potentially read-write)
**After**: Jobs have minimal permissions required (principle of least privilege)

**Resolves**: 8 CodeQL alerts (CWE-275 - Insufficient Privilege Management)
**Severity**: Medium

## Testing

- ✅ All syntax valid (YAML structure preserved)
- ✅ No functional changes to CI pipeline
- ✅ Jobs continue to run with minimal required permissions

## References

- CodeQL Alerts: #1, #2, #3, #4, #5, #6, #7, #8
- [GitHub Docs: Assigning permissions to jobs](https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)