### PR TITLE
fix: remove hardcoded path from test_makefile.sh

### DIFF
--- a/tests/test_makefile.sh
+++ b/tests/test_makefile.sh
@@ -5,7 +5,9 @@
 
 set -e
 
-PROJECT_ROOT="/home/puupa/Projects/Poker/HandEvaluation_C"
+# Get project root directory (parent of tests/)
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 cd "$PROJECT_ROOT"
 
 echo "=========================================="

--- a/tests/test_script_portability.sh
+++ b/tests/test_script_portability.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+# Test script portability - verifies test_makefile.sh doesn't use hardcoded paths
+# This test ensures the script works in any environment (local, CI, etc.)
+
+set -e
+
+echo "=========================================="
+echo "Testing Script Portability"
+echo "=========================================="
+echo ""
+
+# Test 1: Verify no hardcoded absolute paths in script
+echo "[TEST 1] Checking for hardcoded absolute paths..."
+if grep -q "PROJECT_ROOT=\"/home/" tests/test_makefile.sh; then
+    echo "FAIL: Found hardcoded absolute path in test_makefile.sh"
+    grep "PROJECT_ROOT=" tests/test_makefile.sh
+    exit 1
+fi
+echo "PASS: No hardcoded absolute paths found"
+echo ""
+
+# Test 2: Verify script uses relative path logic
+echo "[TEST 2] Verifying script uses relative paths..."
+if ! grep -q 'cd.*dirname.*BASH_SOURCE' tests/test_makefile.sh; then
+    echo "FAIL: Script doesn't use BASH_SOURCE for relative path resolution"
+    exit 1
+fi
+echo "PASS: Script uses relative path resolution"
+echo ""
+
+# Test 3: Run from tests directory
+echo "[TEST 3] Running test_makefile.sh from tests/ directory..."
+cd tests || exit 1
+if ! ./test_makefile.sh > /dev/null 2>&1; then
+    echo "FAIL: Script failed when run from tests/ directory"
+    exit 1
+fi
+cd .. || exit 1
+echo "PASS: Script works from tests/ directory"
+echo ""
+
+# Test 4: Run from project root
+echo "[TEST 4] Running test_makefile.sh from project root..."
+if ! ./tests/test_makefile.sh > /dev/null 2>&1; then
+    echo "FAIL: Script failed when run from project root"
+    exit 1
+fi
+echo "PASS: Script works from project root"
+echo ""
+
+echo "=========================================="
+echo "ALL PORTABILITY TESTS PASSED!"
+echo "=========================================="


### PR DESCRIPTION
## Summary

Fixes CI pipeline failure caused by hardcoded absolute path in test script.

## Changes

- **Removed**: Hardcoded `PROJECT_ROOT="/home/puupa/Projects/Poker/HandEvaluation_C"`
- **Added**: Dynamic path resolution using `BASH_SOURCE` to determine script location
- **Added**: `test_script_portability.sh` to verify portability and prevent regression

## Implementation

The script now calculates the project root directory relative to its own location:

```bash
SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
cd "$PROJECT_ROOT"
```

This works in any environment:
- Local development: `/home/puupa/Projects/Poker/HandEvaluation_C`
- GitHub Actions: `/home/runner/work/poker-hand-evaluation-c/poker-hand-evaluation-c`
- Any other CI/CD environment

## Test Coverage

Added `tests/test_script_portability.sh` which verifies:
1. No hardcoded absolute paths in `test_makefile.sh`
2. Script uses `BASH_SOURCE` for relative path resolution
3. Script works when run from `tests/` directory
4. Script works when run from project root

All existing tests pass without modification.

## Acceptance Criteria Met

- ✅ Test script runs successfully on GitHub Actions (will be verified by CI)
- ✅ Test script still works locally
- ✅ No hardcoded absolute paths in any test scripts
- ✅ CI pipeline passes (pending CI run)

## Verification

```bash
# Run portability test
bash tests/test_script_portability.sh

# Run original Makefile test
bash tests/test_makefile.sh
```

Both tests pass successfully.

Closes #117

🤖 Generated with [Claude Code](https://claude.com/claude-code)