### PR TITLE
fix: eliminate modulo bias in Fisher-Yates shuffle

### DIFF
--- a/tests/test_deck.c
+++ b/tests/test_deck.c
@@ -257,6 +257,72 @@ void test_deck_shuffle_randomness(void) {
     printf("  ✓ Different seeds produce different shuffle results\n");
 }
 
+void test_random_range_basic(void) {
+    printf("Testing random_range basic functionality...\n");
+
+    // Test that random_range returns values in valid range
+    srand(42);
+
+    // Test range [0, 5) - should return 0-4
+    for (int i = 0; i < 100; i++) {
+        size_t r = random_range(5);
+        assert(r < 5);
+    }
+
+    // Test range [0, 1) - should always return 0
+    for (int i = 0; i < 10; i++) {
+        size_t r = random_range(1);
+        assert(r == 0);
+    }
+
+    // Test range [0, 52) - standard deck size
+    for (int i = 0; i < 100; i++) {
+        size_t r = random_range(52);
+        assert(r < 52);
+    }
+
+    printf("  ✓ random_range returns values in valid range\n");
+}
+
+void test_random_range_distribution_uniformity(void) {
+    printf("Testing random_range distribution uniformity (chi-square test)...\n");
+
+    // Test with small range for easier verification
+    const size_t max = 10;
+    const size_t trials = 10000;
+    size_t counts[10] = {0};
+
+    srand(12345);
+
+    // Generate random numbers and count frequency
+    for (size_t i = 0; i < trials; i++) {
+        size_t r = random_range(max);
+        assert(r < max);
+        counts[r]++;
+    }
+
+    // Expected frequency: trials / max
+    double expected = (double)trials / (double)max;
+
+    // Calculate chi-square statistic
+    // χ² = Σ((observed - expected)² / expected)
+    double chi_square = 0.0;
+    for (size_t i = 0; i < max; i++) {
+        double diff = (double)counts[i] - expected;
+        chi_square += (diff * diff) / expected;
+    }
+
+    // For df=9 (max-1) and α=0.05, critical value is 16.919
+    // If chi_square > 16.919, reject null hypothesis (distribution is not uniform)
+    // We expect chi_square to be < 16.919 for uniform distribution
+    printf("    Chi-square statistic: %.2f (critical value: 16.919 at α=0.05)\n", chi_square);
+
+    // Allow some statistical variance - use α=0.01 (critical value 21.666) for more lenient test
+    assert(chi_square < 21.666);
+
+    printf("  ✓ random_range produces uniform distribution (chi-square test passed)\n");
+}
+
 void test_deck_deal_basic(void) {
     printf("Testing deck_deal basic functionality...\n");
 
@@ -539,6 +605,8 @@ int main(void) {
     test_deck_shuffle_preserves_all_cards();
     test_deck_shuffle_changes_order();
     test_deck_shuffle_randomness();
+    test_random_range_basic();
+    test_random_range_distribution_uniformity();
     test_deck_deal_basic();
     test_deck_deal_zero_cards();
     test_deck_deal_all_cards();


### PR DESCRIPTION
## Summary

Fixed modulo bias in the Fisher-Yates shuffle algorithm by implementing an unbiased `random_range()` function using rejection sampling. This eliminates the subtle statistical bias that occurred when `RAND_MAX+1` was not evenly divisible by the range size.

## Changes

- **New Function**: `random_range(max)` - Uses rejection sampling to generate unbiased random numbers
- **Updated**: `deck_shuffle()` - Now uses `random_range(i+1)` instead of `rand() % (i+1)`
- **Documentation**: Added comprehensive comments explaining modulo bias and the rejection sampling solution
- **Tests**: Added chi-square distribution test to verify uniform randomness

## Technical Details

### The Problem
The original implementation used `rand() % (i+1)`, which introduces modulo bias when `RAND_MAX+1` is not evenly divisible by `(i+1)`. For a 52-card deck:
- RAND_MAX = 32767
- RAND_MAX % 52 = 47
- Values 0-47 appear 631 times each
- Values 48-51 appear 630 times each
- Bias: ~0.16% difference

### The Solution
Rejection sampling eliminates this bias by:
1. Calculate limit = RAND_MAX - (RAND_MAX % max)
2. Generate r = rand()
3. If r >= limit, reject and retry
4. Return r % max (now unbiased)

The rejection probability is only ~0.14% (47/32768) for a 52-card deck, making this highly efficient.

## Test Results

All tests pass:
- ✅ All 22 deck tests passing
- ✅ Chi-square test confirms uniform distribution (χ² = 7.06, critical value = 16.919)
- ✅ Valgrind: 0 memory leaks
- ✅ All cards preserved after shuffle
- ✅ Shuffle changes order correctly

## Files Changed

- `include/poker.h` - Added `random_range()` declaration with detailed documentation
- `src/deck.c` - Implemented `random_range()` and updated `deck_shuffle()` to use it
- `tests/test_deck.c` - Added `test_random_range_basic()` and `test_random_range_distribution_uniformity()`

Closes #98

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>