### PR TITLE
refactor: remove unused card_init() placeholder function

### DIFF
--- a/src/card.c
+++ b/src/card.c
@@ -5,10 +5,6 @@
 #include <ctype.h>
 #include "../include/poker.h"
 
-void card_init(void) {
-    /* Placeholder for card initialization */
-}
-
 int card_to_string(const Card card, char* const buffer, const size_t size) {
     // Check buffer size - need at least 3 bytes (2 chars + null terminator)
     if (size < 3) {


### PR DESCRIPTION
## Summary

Removes the unused `card_init()` placeholder function from `src/card.c`. This function was created during project initialization but is never called and has no current or planned purpose.

## Changes

- **src/card.c**: Removed `card_init()` function (lines 8-10)

## Analysis

- Verified `card_init()` is not declared in any header files
- Verified `card_init()` is not called anywhere in the codebase
- Kept `evaluate_hand()` placeholder in `src/evaluator.c` (planned for issue #33)

## Testing

- ✅ All tests pass
- ✅ Library compiles successfully with zero warnings
- ✅ No regressions introduced

Closes #99

🤖 Generated with [Claude Code](https://claude.com/claude-code)